### PR TITLE
fix: resolve WASM compilation errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use wasm_bindgen::prelude::*;
-
 pub mod task;
 pub mod wasm;
 pub mod user_manager;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,7 +1,6 @@
 use wasm_bindgen::prelude::*;
 use crate::task::{TaskManager, Task};
 use std::sync::Mutex;
-use std::collections::HashMap;
 
 // Global task manager instance
 lazy_static::lazy_static! {
@@ -73,8 +72,8 @@ pub fn get_all_tasks_json() -> String {
 #[wasm_bindgen]
 pub struct WasmTask {
     pub id: u32,
-    pub title: String,
-    pub description: String,
+    title: String,
+    description: String,
     pub completed: bool,
 }
 


### PR DESCRIPTION
Fixes WASM compilation errors by:

- Removing unused imports from lib.rs and wasm.rs
- Making String fields private in WasmTask struct to satisfy Copy trait requirements

Fixes #11

Generated with [Claude Code](https://claude.ai/code)