### PR TITLE
fix: remove duplicate getter/setter definitions for WasmTask fields

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -71,10 +71,10 @@ pub fn get_all_tasks_json() -> String {
 
 #[wasm_bindgen]
 pub struct WasmTask {
-    pub id: u32,
+    id: u32,
     title: String,
     description: String,
-    pub completed: bool,
+    completed: bool,
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Fixes #13

Removed duplicate getter/setter definitions for WasmTask fields by making id and completed fields private, since explicit getter methods are already defined.

This resolves the wasm-bindgen compilation error: "There can be only one getter/setter definition for `id` in `WasmTask`"

Generated with [Claude Code](https://claude.ai/code)