### PR TITLE
fix: enable glow feature for eframe WASM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ wasm-bindgen = "0.2"
 web-sys = "0.3"
 js-sys = "0.3"
 lazy_static = "1.4"
-eframe = { version = "0.30", default-features = false, features = ["default_fonts"] }
+eframe = { version = "0.30", default-features = false, features = ["default_fonts", "glow"] }
 egui = "0.30"
 egui_plot = "0.30"
 chrono = { version = "0.4", features = ["serde", "wasm-bindgen"] }


### PR DESCRIPTION
Fixes #21 - WASM build failure due to missing eframe rendering backend feature.

Adds 'glow' feature to eframe dependency to enable OpenGL ES support for web compilation. The eframe 0.30.0 requires either 'glow' or 'wgpu' feature for WASM builds.

Generated with [Claude Code](https://claude.ai/code)