### PR TITLE
fix: resolve WASM compilation errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
-use egui::*;
+use egui::{Context, CentralPanel, Layout, Align, ScrollArea, Color32};
+use eframe::App;
+use egui_plot::{Line, Plot, PlotPoints};
 use crate::kpi_app::KpiApp;
 
 #[derive(Default)]
@@ -23,8 +25,8 @@ impl TaskManagerApp {
     }
 }
 
-impl eframe::App for TaskManagerApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+impl App for TaskManagerApp {
+    fn update(&mut self, ctx: &Context, frame: &mut eframe::Frame) {
         match self.current_view {
             AppView::TaskManager => {
                 self.show_task_manager(ctx, frame);
@@ -37,11 +39,11 @@ impl eframe::App for TaskManagerApp {
 }
 
 impl TaskManagerApp {
-    fn show_task_manager(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| {
+    fn show_task_manager(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
+        CentralPanel::default().show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.heading("🚀 WASM Task Manager");
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                     if ui.button("📊 View KPIs").clicked() {
                         self.current_view = AppView::KpiDashboard;
                     }
@@ -66,11 +68,11 @@ impl TaskManagerApp {
         });
     }
     
-    fn show_kpi_dashboard(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| {
+    fn show_kpi_dashboard(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
+        CentralPanel::default().show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.heading("📊 Task Management KPIs");
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                     if ui.button("← Back to Tasks").clicked() {
                         self.current_view = AppView::TaskManager;
                     }
@@ -167,7 +169,7 @@ impl TaskManagerApp {
                 if tasks.is_empty() {
                     ui.label("No tasks yet. Add one above!");
                 } else {
-                    egui::ScrollArea::vertical().show(ui, |ui| {
+                    ScrollArea::vertical().show(ui, |ui| {
                         for task in tasks.iter() {
                             ui.group(|ui| {
                                 ui.horizontal(|ui| {
@@ -182,7 +184,7 @@ impl TaskManagerApp {
                                         }
                                     });
                                     
-                                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                                         if ui.button("🗑").clicked() {
                                             crate::wasm::remove_task(task.id);
                                         }
@@ -276,7 +278,7 @@ impl TaskManagerApp {
             .show(ui, |plot_ui| {
                 plot_ui.line(
                     Line::new(PlotPoints::from(points))
-                        .color(egui::Color32::from_rgb(100, 200, 100))
+                        .color(Color32::from_rgb(100, 200, 100))
                         .name("Tasks Completed")
                 );
             });

--- a/src/kpi_app.rs
+++ b/src/kpi_app.rs
@@ -1,8 +1,5 @@
 use egui::*;
 use egui_plot::{Line, Plot, PlotPoints};
-use chrono::{DateTime, Utc, Duration};
-use crate::task::TaskManager;
-use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct KpiApp {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,7 +1,9 @@
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use crate::task::{TaskManager, Task};
 use crate::app::TaskManagerApp;
 use std::sync::Mutex;
+use web_sys::HtmlCanvasElement;
 
 // Global task manager instance
 lazy_static::lazy_static! {
@@ -170,12 +172,20 @@ pub fn start_egui_app(canvas_id: &str) {
     
     let web_options = eframe::WebOptions::default();
     
-    wasm_bindgen_futures::spawn_local(async {
+    wasm_bindgen_futures::spawn_local(async move {
+        let window = web_sys::window().unwrap();
+        let document = window.document().unwrap();
+        let canvas = document
+            .get_element_by_id(canvas_id)
+            .unwrap()
+            .dyn_into::<HtmlCanvasElement>()
+            .unwrap();
+        
         let result = eframe::WebRunner::new()
             .start(
-                canvas_id,
+                canvas,
                 web_options,
-                Box::new(|_cc| Box::new(TaskManagerApp::new())),
+                Box::new(|_cc| Ok(Box::new(TaskManagerApp::new()))),
             )
             .await;
             


### PR DESCRIPTION
This PR fixes the compilation errors preventing the WASM build from succeeding.

## Changes
- Remove unused imports from kpi_app.rs
- Fix type mismatches in wasm.rs
- Fix unused imports and variables in app.rs

Closes #23

Generated with [Claude Code](https://claude.ai/code)